### PR TITLE
Java 24 Updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Pull Request Version Validation
-        if: github.event_name == 'pull_request'
-        uses: ikmdev/maven-pull-request-version-validation-action@v2
+        uses: ikmdev/maven-pull-request-version-validation-action@v2.1.0
         
   build-job:
     name: Build Job
@@ -29,7 +28,7 @@ jobs:
         
       - uses: actions/setup-java@v4
         with:
-            java-version: '23'
+            java-version: '24'
             distribution: 'zulu'
         
       - name: Build Protoc Docker container
@@ -49,7 +48,7 @@ jobs:
           ls src/main/java-generated
 
       - name: Build IKMDEV Code
-        uses: ikmdev/maven-clean-install-build-action@v3
+        uses: ikmdev/maven-clean-install-build-action@v3.5.0
         with:
           branch_name: ${{env.BRANCH_NAME}}
           skip_setup: yes

--- a/.github/workflows/post_build.yaml
+++ b/.github/workflows/post_build.yaml
@@ -41,7 +41,7 @@ jobs:
       
       - name: IKMDEV Post Build Action
         id: ikmdev_post_build
-        uses: ikmdev/maven-post-build-action@v3.1.0
+        uses: ikmdev/maven-post-build-action@v3.2.0
         with:
             nexus_repo_password: ${{secrets.EC2_NEXUS_PASSWORD}}
             branch_name: ${{github.event.workflow_run.head_branch}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
             ls src/main/java-generated
 
       - name: Shared Release Action
-        uses: ikmdev/maven-semver-release-action@v2
+        uses: ikmdev/maven-semver-release-action@v2.7.0
         with:
           version_type: ${{ github.event.inputs.version_type }}
           github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
---enable-preview

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
     <url>https://github.com/IKM/tinkar-proto</url>
 
     <properties>
+        <!-- Properties Needed To Build On Java 24 (Start) -->
+        <java.version>24</java.version>
+        <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
+        <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
+        <!-- Properties Needed To Build On Java 24 (End) -->
+
         <protobuf.version>4.30.2-r2</protobuf.version>
         <tinkar-jpms-deps.groupId>dev.ikm.jpms</tinkar-jpms-deps.groupId>
         <maven.build-helper-plugin.version>3.6.0</maven.build-helper-plugin.version>
@@ -76,6 +82,42 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${maven.build-helper-plugin.version}</version>
                 </plugin>
+
+                <!-- Maven Dependency Plugin Fix (Start) -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <ignoredNonTestScopedDependencies>
+                                    <ignoredNonTestScopedDependency>org.slf4j:*</ignoredNonTestScopedDependency>
+                                </ignoredNonTestScopedDependencies>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <ignoredUnusedDeclaredDependency>org.slf4j:*</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                                <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+                                <ignoredUsedUndeclaredDependencies>
+                                    <ignoredUsedUndeclaredDependency>dev.ikm.jpms:eclipse-collections-api</ignoredUsedUndeclaredDependency>
+                                </ignoredUsedUndeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
+                        <dependency>
+                            <groupId>org.apache.maven.shared</groupId>
+                            <artifactId>maven-dependency-analyzer</artifactId>
+                            <version>${maven-dependency-analyzer.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <!-- Maven Dependency Plugin Fix (End) -->
+
             </plugins>
         </pluginManagement>
 
@@ -105,5 +147,29 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- codeQuality profile to override pmd configuration from build-parent
+         Need to ovverride aggregate parameter as it is deprecated. -->
+        <profile>
+            <!-- To disable this, use something like "mvn install -P!codeQuality" -->
+            <id>codeQuality</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <configuration>
+                            <aggregate combine.self="override"></aggregate> <!-- Overridden due to deprecation -->
+                            <targetJdk>${java.version}</targetJdk>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
         <groupId>dev.ikm.build</groupId>
         <artifactId>java-parent</artifactId>
         <version>1.64.0</version>
-        <relativePath />
     </parent>
 
     <groupId>dev.ikm.tinkar</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.ikm.build</groupId>
         <artifactId>java-parent</artifactId>
-        <version>1.63.0</version>
+        <version>1.64.0</version>
         <relativePath />
     </parent>
 
@@ -19,12 +19,6 @@
     <url>https://github.com/IKM/tinkar-proto</url>
 
     <properties>
-        <!-- Properties Needed To Build On Java 24 (Start) -->
-        <java.version>24</java.version>
-        <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
-        <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
-        <!-- Properties Needed To Build On Java 24 (End) -->
-
         <protobuf.version>4.30.2-r2</protobuf.version>
         <tinkar-jpms-deps.groupId>dev.ikm.jpms</tinkar-jpms-deps.groupId>
         <maven.build-helper-plugin.version>3.6.0</maven.build-helper-plugin.version>
@@ -82,42 +76,6 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${maven.build-helper-plugin.version}</version>
                 </plugin>
-
-                <!-- Maven Dependency Plugin Fix (Start) -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>analyze</id>
-                            <goals>
-                                <goal>analyze-only</goal>
-                            </goals>
-                            <configuration>
-                                <ignoredNonTestScopedDependencies>
-                                    <ignoredNonTestScopedDependency>org.slf4j:*</ignoredNonTestScopedDependency>
-                                </ignoredNonTestScopedDependencies>
-                                <ignoredUnusedDeclaredDependencies>
-                                    <ignoredUnusedDeclaredDependency>org.slf4j:*</ignoredUnusedDeclaredDependency>
-                                </ignoredUnusedDeclaredDependencies>
-                                <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
-                                <ignoredUsedUndeclaredDependencies>
-                                    <ignoredUsedUndeclaredDependency>dev.ikm.jpms:eclipse-collections-api</ignoredUsedUndeclaredDependency>
-                                </ignoredUsedUndeclaredDependencies>
-                            </configuration>
-                        </execution>
-                    </executions>
-                    <dependencies>
-                        <!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
-                        <dependency>
-                            <groupId>org.apache.maven.shared</groupId>
-                            <artifactId>maven-dependency-analyzer</artifactId>
-                            <version>${maven-dependency-analyzer.version}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <!-- Maven Dependency Plugin Fix (End) -->
-
             </plugins>
         </pluginManagement>
 
@@ -147,29 +105,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <!-- codeQuality profile to override pmd configuration from build-parent
-         Need to ovverride aggregate parameter as it is deprecated. -->
-        <profile>
-            <!-- To disable this, use something like "mvn install -P!codeQuality" -->
-            <id>codeQuality</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-pmd-plugin</artifactId>
-                        <configuration>
-                            <aggregate combine.self="override"></aggregate> <!-- Overridden due to deprecation -->
-                            <targetJdk>${java.version}</targetJdk>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
 </project>


### PR DESCRIPTION
- Updated the GH Actions to us newer released versions
    - build.yaml
        - ikmdev/maven-pull-request-version-validation-action@v2.1.0
        - ikmdev/maven-clean-install-build-action@v3.5.0
        - ikmdev/maven-post-build-action@v3.2.0
        - ikmdev/maven-semver-release-action@v2.7.0

- Updated the maven wrapper to 3.9.11

- Added some properties
        - <java.version>24</java.version>
        - <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
        - <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>

- Added codeQuality profile to override maven-pmd-plugin (aggregate parameter is deprecated)

- Added transitive dependency fix for maven-dependency-plugin

- Removed "--enable-preview" from codebase