### PR TITLE
Bundle Tinkar proto as resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,15 @@
             </plugins>
         </pluginManagement>
 
+        <resources>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>Tinkar.proto</include>
+                </includes>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
The standalone tinkar-service will use the bundled Tinkar.proto